### PR TITLE
fix: use another way (Close #195)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -243,12 +243,18 @@ export function getUrlParam(url: string, param: string): string | string[] {
  * @category URL
  */
 export function updateQueryParam(url: string, param: string, value: string): string {
-  const re = new RegExp('([?&])' + param + '=.*?(&|$)', 'i');
-  const separator = url.indexOf('?') !== -1 ? '&' : '?';
-  if (url.match(re)) {
-    return url.replace(re, '$1' + param + '=' + value + '$2');
+  if (url.includes('#')) {
+    const urlObj = new URL(url);
+    urlObj.searchParams.set(param, value);
+    return urlObj.toString();
   } else {
-    return url + separator + param + '=' + value;
+    const re = new RegExp('([?&])' + param + '=.*?(&|$)', 'i');
+    const separator = url.indexOf('?') !== -1 ? '&' : '?';
+    if (url.match(re)) {
+      return url.replace(re, '$1' + param + '=' + value + '$2');
+    } else {
+      return url + separator + param + '=' + value;
+    }
   }
 }
 

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -3,7 +3,7 @@
  */
 /* eslint-disable no-undef */
 /* eslint-disable quotes */
-import { isValidUrl, getUrlFileType, isValidHttpUrl } from '../lib/index.esm';
+import { isValidUrl, getUrlFileType, isValidHttpUrl, updateQueryParam } from '../lib/index.esm';
 // import { isValidUrl, getUrlFileType, isValidHttpUrl } from '../src/index';
 
 const validUrls = [
@@ -100,4 +100,31 @@ describe('isValidHttpUrl', () => {
     expect(isValidHttpUrl(`https://this-shouldn't.match@example.com`, { strict: false })).toBe(false);
     expect(isValidHttpUrl('abcdef', { strict: false })).toBe(false);
   });
+});
+
+// Test case 1: URL with existing query parameter
+test('Update existing query parameter in URL', () => {
+  const url = 'https://example.com/page?param1=value1&param2=value2';
+  const param = 'param1';
+  const value = 'updatedValue';
+  const updatedUrl = updateQueryParam(url, param, value);
+  expect(updatedUrl).toBe('https://example.com/page?param1=updatedValue&param2=value2');
+});
+
+// Test case 2: URL without existing query parameter
+test('Add new query parameter to URL', () => {
+  const url = 'https://example.com/page';
+  const param = 'param1';
+  const value = 'newValue';
+  const updatedUrl = updateQueryParam(url, param, value);
+  expect(updatedUrl).toBe('https://example.com/page?param1=newValue');
+});
+
+// Test case 3: URL with hash fragment
+test('Update query parameter in URL with hash fragment', () => {
+  const url = 'https://example.com/page#section1';
+  const param = 'param1';
+  const value = 'updatedValue';
+  const updatedUrl = updateQueryParam(url, param, value);
+  expect(updatedUrl).toBe('https://example.com/page?param1=updatedValue#section1');
 });


### PR DESCRIPTION
Use another way(`new URL`) when the parameter doesn't exist and the URL includes the hash string.

Close #195